### PR TITLE
Add new locale: es (spanish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Currently supported languages:
 - pl
 - pt
 - it
+- es
 
 Custom locales can be provided via a ``customLocales`` prop:
 ```

--- a/src/buefy/core/i18n.ts
+++ b/src/buefy/core/i18n.ts
@@ -106,6 +106,33 @@ export const defaultLocales: Record<string, Record<string, string>> = {
         monthly: "MENSAL",
         advanced: "AVANÇADO",
         cronExpression: "Expressão cron:"
+    },
+    es: {
+        every: "Cada",
+        mminutes: "minuto(s)",
+        hoursOnMinute: "hora(s), en el minuto",
+        daysAt: "dia(s) a las",
+        at: "a las",
+        onThe: "El día",
+        dayOfEvery: "del mes, cada",
+        monthsAt: "mes(es), a las",
+        everyDay: "Cada",
+        mon: "Lun",
+        tue: "Mar",
+        wed: "Mie",
+        thu: "Jue",
+        fri: "Vie",
+        sat: "Sáb",
+        sun: "Dom",
+        hasToBeBetween: "Entre",
+        and: "y",
+        minutes: "CADA MINUTO(s)",
+        hourly: "CADA HORA(s)",
+        daily: "DIARIAMENTE",
+        weekly: "SEMANALMENTE",
+        monthly: "MENSUALMENTE",
+        advanced: "AVANZADO",
+        cronExpression: "Expresión CRON:"
     }
 };
 


### PR DESCRIPTION
Hello!

As I proposed on #50 , I added support for **spanish** language.

To use it, change `locale` to `es`.

There are some inconsistencies due the huge difference between spanish's syntax and english's syntax, anyway its not a big deal.

I think it could be fixed if we could have a custom layout for some locales, but it could be tricky and probably contain breaking changes. **I'd love to hear your opinions about this.**

Some screenshots:

![image](https://user-images.githubusercontent.com/3205737/91861195-edcf3d80-ec42-11ea-8ab5-10a6615b4939.png)

![image](https://user-images.githubusercontent.com/3205737/91861309-09d2df00-ec43-11ea-863b-a7b961fd9c76.png)

